### PR TITLE
Developer improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "own3d-desktop",
   "productName": "OWN3D Pro Desktop",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "OWN3D Pro Desktop",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/ipc/core.ts
+++ b/src/ipc/core.ts
@@ -19,7 +19,7 @@ export function registerCoreHandlers() {
     ipcMain.handle('games', async () => gameWatcher.getGames())
     ipcMain.handle('version', async () => app.getVersion())
     ipcMain.handle('settings', async () => settingsRepository.getSettings())
-    ipcMain.handle('needs-devtools', async () => !!argv.devtools)
+    ipcMain.handle('needs-devtools', async () => argv.devtools && ['all', true].includes(argv.devtools))
     ipcMain.handle('hostname', async () => hostname)
     ipcMain.handle('preload', function () {
         return path.join(__dirname, 'preload.js')

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { useRpcServer } from './composables/useRpcServer'
 
 export interface Argv {
     _: string[]
-    devtools?: boolean
+    devtools?: string | boolean
     localhost?: boolean
     hostname?: string
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,10 +7,13 @@ import { RequestBatchOptions, RequestBatchRequest, ResponseMessage } from 'obs-w
 import IpcRendererEvent = Electron.IpcRendererEvent
 import { InstallProgress, SoftwareName } from './composables/useSoftware'
 
+import packageJson from '../package.json'
+
 contextBridge.exposeInMainWorld('versions', {
     node: () => process.versions.node,
     chrome: () => process.versions.chrome,
     electron: () => process.versions.electron,
+    desktop: () => packageJson.version,
 })
 
 contextBridge.exposeInMainWorld('electron', {

--- a/src/window/mainWindow.ts
+++ b/src/window/mainWindow.ts
@@ -40,7 +40,7 @@ export function createMainWindow() {
     }
 
     // Open the DevTools.
-    if (argv.devtools) {
+    if (argv.devtools && ['all', 'main'].includes(argv.devtools)) {
         windows.mainWindow.webContents.openDevTools()
     }
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and flexibility of the application, particularly around the handling of the `devtools` argument and exposing the application version in the preload script.

### Enhancements to `devtools` argument handling:

* [`src/ipc/core.ts`](diffhunk://#diff-143ac2da1420bbec01918192b3ebb83d4c34de4c294dfd0ec45efe82e540aec1L22-R22): Modified the `needs-devtools` handler to check if `argv.devtools` includes 'all' or `true` to provide more granular control over devtools activation.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL24-R24): Updated the `Argv` interface to allow `devtools` to be either a string or a boolean, giving more flexibility in how the argument can be used.
* [`src/window/mainWindow.ts`](diffhunk://#diff-25beb4b60878faca81b5a6ac7b714c47750a39b53872b99b441c156f67eed24dL43-R43): Adjusted the condition to open DevTools only if `argv.devtools` includes 'all' or 'main', refining the control over which windows open DevTools.

### Exposing application version:

* [`src/preload.ts`](diffhunk://#diff-9bf33f12c0002eeec39a2d3439dbe26fb3004ab67f714bb384122169cfaff491R10-R16): Added `desktop` to the `versions` object to expose the application version from `package.json` in the preload script, making it accessible in the renderer process.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the application version from `2.3.0` to `2.4.0`.